### PR TITLE
Fix split_into_sentences ']]' bug

### DIFF
--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1546,10 +1546,10 @@ def parse_tokens(txt: Union[str, Iterable[str]], **options: Any) -> Iterator[Tok
                 ):
                     # Begin or end paragraph marker
                     marker, rt = rt.split(2)
-                    if marker.txt == "[[" and not inside_paragraph_marker:
+                    if marker.txt == "[[":
                         yield TOK.Begin_Paragraph(marker)
                         inside_paragraph_marker = True
-                    elif marker.txt == "]]" and inside_paragraph_marker:
+                    elif marker.txt == "]]":
                         yield TOK.End_Paragraph(marker)
                         inside_paragraph_marker = False
                 elif rtxt[0] in HYPHENS:

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -453,6 +453,7 @@ class TOK:
     X_END = 12001
 
     END = frozenset((P_END, S_END, X_END, S_SPLIT))
+    BEGIN = frozenset((P_BEGIN, S_BEGIN))
     TEXT = frozenset((WORD, PERSON, ENTITY, MOLECULE, COMPANY))
     TEXT_EXCL_PERSON = frozenset((WORD, ENTITY, MOLECULE, COMPANY))
 
@@ -1545,10 +1546,10 @@ def parse_tokens(txt: Union[str, Iterable[str]], **options: Any) -> Iterator[Tok
                 ):
                     # Begin or end paragraph marker
                     marker, rt = rt.split(2)
-                    if marker.txt == "[[":
+                    if marker.txt == "[[" and not inside_paragraph_marker:
                         yield TOK.Begin_Paragraph(marker)
                         inside_paragraph_marker = True
-                    elif inside_paragraph_marker:
+                    elif marker.txt == "]]" and inside_paragraph_marker:
                         yield TOK.End_Paragraph(marker)
                         inside_paragraph_marker = False
                 elif rtxt[0] in HYPHENS:
@@ -2881,7 +2882,7 @@ def split_into_sentences(
                 else:
                     yield " ".join(curr_sent)
             curr_sent = []
-        else:
+        elif t.kind not in TOK.BEGIN:
             txt = to_text(t)
             if txt:
                 curr_sent.append(txt)

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1406,7 +1406,7 @@ def parse_tokens(txt: Union[str, Iterable[str]], **options: Any) -> Iterator[Tok
     #    exhausted. At that point, we obtain the next token and start from 2).
 
     rt: Tok
-
+    inside_paragraph_marker: bool = False
     for rt in generate_rough_tokens(
         txt, replace_composite_glyphs, replace_html_escapes, one_sent_per_line
     ):
@@ -1539,13 +1539,18 @@ def parse_tokens(txt: Union[str, Iterable[str]], **options: Any) -> Iterator[Tok
                     # Probably an idiot trying to type opening double quotes with commas
                     punct, rt = rt.split(2)
                     yield TOK.Punctuation(punct, normalized="„")
-                elif lw >= 2 and (rtxt.startswith("[[") or rtxt.startswith("]]")):
+                elif lw >= 2 and (
+                    (rtxt.startswith("[[") and not inside_paragraph_marker)
+                    or (rtxt.startswith("]]") and inside_paragraph_marker)
+                ):
                     # Begin or end paragraph marker
                     marker, rt = rt.split(2)
                     if marker.txt == "[[":
                         yield TOK.Begin_Paragraph(marker)
-                    else:
+                        inside_paragraph_marker = True
+                    elif inside_paragraph_marker:
                         yield TOK.End_Paragraph(marker)
+                        inside_paragraph_marker = False
                 elif rtxt[0] in HYPHENS:
                     # Normalize all hyphens the same way
                     punct, rt = rt.split(1)

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -1844,12 +1844,28 @@ def test_split_sentences() -> None:
     sents = list(g)
     assert len(sents) == 0
 
-    g = t.split_into_sentences("Athugum [hvort [setninging sé rétt skilin]].")
+    g = t.split_into_sentences("Athugum [hvort [setningin sé rétt skilin]].")
     sents = list(g)
     assert len(sents) == 1
     assert sents == [
-        "Athugum [ hvort [ setninging sé rétt skilin ] ] ."
+        "Athugum [ hvort [ setningin sé rétt skilin ] ] ."
     ]
+
+    g = t.split_into_sentences("Þessi [ætti [líka að]] vera rétt skilin.")
+    sents = list(g)
+    assert len(sents) == 1
+    assert sents == [
+        "Þessi [ ætti [ líka að ] ] vera rétt skilin ."
+    ]
+
+    # g = t.split_into_sentences("Þessi á [[líka að]] vera rétt skilin.")
+    # sents = list(g)
+    # assert len(sents) == 3
+    # assert sents == [
+    #     "Þessi á",
+    #     "[[ líka að ]]",
+    #     "vera rétt skilin ."
+    # ]
     # Test onesentperline
 
 

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -1844,6 +1844,12 @@ def test_split_sentences() -> None:
     sents = list(g)
     assert len(sents) == 0
 
+    g = t.split_into_sentences("Athugum [hvort [setninging sé rétt skilin]].")
+    sents = list(g)
+    assert len(sents) == 1
+    assert sents == [
+        "Athugum [ hvort [ setninging sé rétt skilin ] ] ."
+    ]
     # Test onesentperline
 
 


### PR DESCRIPTION
Only parse paragraph end marker as such when a paragraph start marker has been encountered.
See bug #32 