### PR TITLE
Ospl

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Miðeind ehf.
+Copyright (C) 2022 Miðeind ehf.
 Original author: Vilhjálmur Þorsteinsson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
     Tokenizer for Icelandic text
 
-    Copyright (C) 2021 Miðeind ehf.
+    Copyright (C) 2022 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:

--- a/src/tokenizer/Abbrev.conf
+++ b/src/tokenizer/Abbrev.conf
@@ -1,7 +1,7 @@
 #
 # List of abbreviations for tokenization of Icelandic text
 #
-# Copyright (C) 2021 Miðeind ehf.
+# Copyright (C) 2022 Miðeind ehf.
 # Original author: Vilhjálmur Þorsteinsson
 #
 # This software is licensed under the MIT License:

--- a/src/tokenizer/__init__.py
+++ b/src/tokenizer/__init__.py
@@ -1,6 +1,6 @@
 """
 
-    Copyright(C) 2021 Miðeind ehf.
+    Copyright(C) 2022 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -62,7 +62,7 @@ from .abbrev import Abbreviations, ConfigError
 from .version import __version__
 
 __author__ = "Miðeind ehf"
-__copyright__ = "(C) 2021 Miðeind ehf."
+__copyright__ = "(C) 2022 Miðeind ehf."
 
 __all__ = (
     "__author__",

--- a/src/tokenizer/abbrev.py
+++ b/src/tokenizer/abbrev.py
@@ -2,7 +2,7 @@
 
     Abbreviations module for tokenization of Icelandic text
 
-    Copyright (C) 2021 Miðeind ehf.
+    Copyright (C) 2022 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:

--- a/src/tokenizer/definitions.py
+++ b/src/tokenizer/definitions.py
@@ -2,7 +2,7 @@
 
     Definitions used for tokenization of Icelandic text
 
-    Copyright (C) 2021 Miðeind ehf.
+    Copyright (C) 2022 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:

--- a/src/tokenizer/main.py
+++ b/src/tokenizer/main.py
@@ -3,7 +3,7 @@
 
     Tokenizer for Icelandic text
 
-    Copyright (C) 2021 Miðeind ehf.
+    Copyright (C) 2022 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1718,23 +1718,18 @@ class PunctuationParser:
                     punct, rt = rt.split(1)
                     yield TOK.Punctuation(punct)
             elif len(rtxt) > 4:
-                # Probably '???!!!' or something of the sort
+                # Possibly '???!!!' or something of the sort
                 # Normalize to the first punctuation mark
                 numpunct = 0
-                notallpunct = False
                 for p in rtxt:
                     if p in PUNCTUATION:
                         numpunct += 1
-                    else:
-                        # Something like (word) or "*word*"
-                        notallpunct = True
-                        break
-                if notallpunct:
-                    punct, rt = rt.split(1)
-                    yield TOK.Punctuation(punct)
-                else:
+                if numpunct == len(rtxt):
                     punct, rt = rt.split(numpunct)
                     yield TOK.Punctuation(punct, normalized=rtxt[0])
+                else:
+                    punct, rt = rt.split(1)
+                    yield TOK.Punctuation(punct)
             else:
                 punct, rt = rt.split(1)
                 yield TOK.Punctuation(punct)

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1721,10 +1721,20 @@ class PunctuationParser:
                 # Probably '???!!!' or something of the sort
                 # Normalize to the first punctuation mark
                 numpunct = 0
+                notallpunct = False
                 for p in rtxt:
-                    numpunct += 1
-                punct, rt = rt.split(numpunct)
-                yield TOK.Punctuation(punct, normalized=rtxt[0])
+                    if p in PUNCTUATION:
+                        numpunct += 1
+                    else:
+                        # Something like (word) or "*word*"
+                        notallpunct = True
+                        break
+                if notallpunct:
+                    punct, rt = rt.split(1)
+                    yield TOK.Punctuation(punct)
+                else:
+                    punct, rt = rt.split(numpunct)
+                    yield TOK.Punctuation(punct, normalized=rtxt[0])
             else:
                 punct, rt = rt.split(1)
                 yield TOK.Punctuation(punct)

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1656,7 +1656,7 @@ class PunctuationParser:
                 punct, rt = rt.split(3)
                 yield TOK.Punctuation(punct)
             elif rtxt.startswith("..."):
-                # Treat ellipsis as one piece of punctuation
+                # Treat three periods as ellipsis, one piece of punctuation
                 numdots = 0
                 for c in rtxt:
                     if c == ".":
@@ -1676,14 +1676,16 @@ class PunctuationParser:
                 dots, rt = rt.split(numdots)
                 yield TOK.Punctuation(dots, normalized="…")
                 # TODO LAGA Hér ætti að safna áfram.
+            elif rtxt.startswith(".."):
+                # Normalize two periods to one
+                dots, rt = rt.split(4)
+                yield TOK.Punctuation(dots, normalized=".")
             # TODO Was at the end of a word or by itself, should be ",".
-            # Won't correct automatically, check for M6
             elif rt.txt == ",,":
                 punct, rt = rt.split(2)
                 yield TOK.Punctuation(punct, normalized=",")
-            # TODO STILLING kommum í upphafi orðs breytt í gæsalappir
             elif rtxt.startswith(",,"):
-                # Probably an idiot trying to type opening double quotes with commas
+                # Probably someone trying to type opening double quotes with commas
                 punct, rt = rt.split(2)
                 yield TOK.Punctuation(punct, normalized="„")
             elif rtxt[0] in HYPHENS:
@@ -1715,6 +1717,14 @@ class PunctuationParser:
                     # Return the @-sign and leave the rest
                     punct, rt = rt.split(1)
                     yield TOK.Punctuation(punct)
+            elif len(rtxt) > 4:
+                # Probably '???!!!' or something of the sort
+                # Normalize to the first punctuation mark
+                numpunct = 0
+                for p in rtxt:
+                    numpunct += 1
+                punct, rt = rt.split(numpunct)
+                yield TOK.Punctuation(punct, normalized=rtxt[0])
             else:
                 punct, rt = rt.split(1)
                 yield TOK.Punctuation(punct)

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -2238,14 +2238,14 @@ def parse_particles(token_stream: Iterator[Tok], **options: Any) -> Iterator[Tok
                 ):
                     # Ordinal, i.e. whole number or Roman numeral followed by period:
                     # convert to an ordinal token
-                    follow_token = token_stream[0]
-                    if follow_token and not (
-                        follow_token.kind in TOK.END
-                        or follow_token.punctuation in {"„", '"'}
+                    ord_token: Optional[Tok] = token_stream[0]
+                    if ord_token and not (
+                        ord_token.kind in TOK.END
+                        or ord_token.punctuation in {"„", '"'}
                         or (
-                            follow_token.kind == TOK.WORD
-                            and follow_token.txt[0].isupper()
-                            and month_for_token(follow_token, True) is None
+                            ord_token.kind == TOK.WORD
+                            and ord_token.txt[0].isupper()
+                            and month_for_token(ord_token, True) is None
                         )
                     ):
                         # OK: replace the number/Roman numeral and the period

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -2,7 +2,7 @@
 
     Tokenizer for Icelandic text
 
-    Copyright (C) 2021 Miðeind ehf.
+    Copyright (C) 2022 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -66,6 +66,11 @@ from .abbrev import Abbreviations
 
 
 _T = TypeVar("_T", bound="Tok")
+
+
+# Set of punctuation characters that are grouped into one
+# normalized exclamation
+EXCLAMATIONS = frozenset(("!", "?"))
 
 
 class Tok:
@@ -1655,39 +1660,34 @@ class PunctuationParser:
             elif rtxt.startswith("[…]"):
                 punct, rt = rt.split(3)
                 yield TOK.Punctuation(punct)
-            elif rtxt.startswith("..."):
-                # Treat three periods as ellipsis, one piece of punctuation
+            elif rtxt.startswith("...") or rtxt.startswith("…"):
+                # Treat >= 3 periods as ellipsis, one piece of punctuation
                 numdots = 0
                 for c in rtxt:
-                    if c == ".":
+                    if c == "." or c == "…":
                         numdots += 1
                     else:
                         break
                 dots, rt = rt.split(numdots)
                 yield TOK.Punctuation(dots, normalized="…")
-            elif rtxt.startswith("…"):
-                # Treat ellipsis as one piece of punctuation
-                numdots = 0
-                for c in rtxt:
-                    if c == "…":
-                        numdots += 1
-                    else:
-                        break
-                dots, rt = rt.split(numdots)
-                yield TOK.Punctuation(dots, normalized="…")
-                # TODO LAGA Hér ætti að safna áfram.
             elif rtxt.startswith(".."):
                 # Normalize two periods to one
-                dots, rt = rt.split(4)
+                dots, rt = rt.split(2)
                 yield TOK.Punctuation(dots, normalized=".")
-            # TODO Was at the end of a word or by itself, should be ",".
-            elif rt.txt == ",,":
-                punct, rt = rt.split(2)
-                yield TOK.Punctuation(punct, normalized=",")
-            elif rtxt.startswith(",,"):
+            elif rtxt.startswith(",,") and rtxt[2:3].isalpha():
                 # Probably someone trying to type opening double quotes with commas
                 punct, rt = rt.split(2)
                 yield TOK.Punctuation(punct, normalized="„")
+            elif rtxt.startswith(",,"):
+                # Coalesce multiple commas into one normalized comma
+                numcommas = 2
+                for c in rtxt[2:]:
+                    if c == ",":
+                        numcommas += 1
+                    else:
+                        break
+                punct, rt = rt.split(numcommas)
+                yield TOK.Punctuation(punct, normalized=",")
             elif rtxt[0] in HYPHENS:
                 # Normalize all hyphens the same way
                 punct, rt = rt.split(1)
@@ -1717,19 +1717,16 @@ class PunctuationParser:
                     # Return the @-sign and leave the rest
                     punct, rt = rt.split(1)
                     yield TOK.Punctuation(punct)
-            elif len(rtxt) > 4:
+            elif len(rtxt) >= 2 and frozenset(rtxt) <= EXCLAMATIONS:
                 # Possibly '???!!!' or something of the sort
-                # Normalize to the first punctuation mark
-                numpunct = 0
-                for p in rtxt:
-                    if p in PUNCTUATION:
+                numpunct = 2
+                for p in rtxt[2:]:
+                    if p in EXCLAMATIONS:
                         numpunct += 1
-                if numpunct == len(rtxt):
-                    punct, rt = rt.split(numpunct)
-                    yield TOK.Punctuation(punct, normalized=rtxt[0])
-                else:
-                    punct, rt = rt.split(1)
-                    yield TOK.Punctuation(punct)
+                    else:
+                        break
+                punct, rt = rt.split(numpunct)
+                yield TOK.Punctuation(punct, normalized=rtxt[0])
             else:
                 punct, rt = rt.split(1)
                 yield TOK.Punctuation(punct)

--- a/test/test_detokenize.py
+++ b/test/test_detokenize.py
@@ -6,7 +6,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2021 by Miðeind ehf.
+    Copyright (C) 2022 by Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -61,6 +61,7 @@ def test_detokenize() -> None:
         "Páll var með \"netfangið\" palli@einn.i.heiminum.is.",
         "Páll var með „netfangið“ palli@einn.i.heiminum.is."
     )
+
     # !!! BUG
     #should_be(
     #    "Páll var með \"netfangið\", þ.e.a.s. (\"þetta\").",

--- a/test/test_index_calculation.py
+++ b/test/test_index_calculation.py
@@ -6,7 +6,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2021 by Miðeind ehf.
+    Copyright (C) 2022 by Miðeind ehf.
 
     This software is licensed under the MIT License:
 

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -5,7 +5,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2021 by Miðeind ehf.
+    Copyright (C) 2022 by Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -2345,6 +2345,31 @@ def test_normalization() -> None:
     toklist = list(t.tokenize('Hann sagði: "Þú ert ágæt!".'))
     assert t.text_from_tokens(toklist) == 'Hann sagði : " Þú ert ágæt ! " .'
     assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt ! “ ."
+
+    toklist = list(t.tokenize('Hann sagði: ,,Þú ert ágæt!!??!".'))
+    assert t.text_from_tokens(toklist) == 'Hann sagði : ,, Þú ert ágæt !!??! " .'
+    assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt ! “ ."
+
+    toklist = list(t.tokenize('Hann sagði: ,,Þú ert ágæt??!?".'))
+    assert t.text_from_tokens(toklist) == 'Hann sagði : ,, Þú ert ágæt ??!? " .'
+    assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt ? “ ."
+
+    toklist = list(t.tokenize('Jón,, farðu út.'))
+    assert t.text_from_tokens(toklist) == 'Jón ,, farðu út .'
+    assert t.normalized_text_from_tokens(toklist) == "Jón , farðu út ."
+
+    toklist = list(t.tokenize('Jón ,,farðu út.'))
+    assert t.text_from_tokens(toklist) == 'Jón ,, farðu út .'
+    assert t.normalized_text_from_tokens(toklist) == "Jón „ farðu út ."
+
+    toklist = list(t.tokenize('Hann sagði: ,,Þú ert ágæt.....".'))
+    assert t.text_from_tokens(toklist) == 'Hann sagði : ,, Þú ert ágæt ..... " .'
+    assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt … “ ."
+
+    toklist = list(t.tokenize('Hann sagði: ,,Þú ert ágæt…..".'))
+    assert t.text_from_tokens(toklist) == 'Hann sagði : ,, Þú ert ágæt ….. " .'
+    assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt … “ ."
+
 
 
 def test_abbr_at_eos() -> None:

--- a/test/test_tokenizer_tok.py
+++ b/test/test_tokenizer_tok.py
@@ -3,7 +3,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2021 by Miðeind ehf.
+    Copyright (C) 2022 by Miðeind ehf.
 
     This software is licensed under the MIT License:
 


### PR DESCRIPTION
- one_sent_per_line function reverted; --original does the job instead.
- Two periods normalized to one; I can't find any case where that is valid.
- More than 4 punctuation marks normalized to the first one.