### PR TITLE
Puncterrors

### DIFF
--- a/src/tokenizer/definitions.py
+++ b/src/tokenizer/definitions.py
@@ -54,6 +54,7 @@ AmountTuple = Tuple[float, str, Optional[List[str]], Optional[List[str]]]
 TelnoTuple = Tuple[str, str]
 CurrencyTuple = Tuple[str, Optional[List[str]], Optional[List[str]]]
 
+
 class BIN_Tuple(NamedTuple):
     stofn: str
     utg: int
@@ -62,12 +63,15 @@ class BIN_Tuple(NamedTuple):
     ordmynd: str
     beyging: str
 
+
 BIN_TupleList = Sequence[BIN_Tuple]
+
 
 class PersonNameTuple(NamedTuple):
     name: str
     gender: Optional[str]
     case: Optional[str]
+
 
 PersonNameList = Sequence[PersonNameTuple]
 
@@ -193,6 +197,9 @@ PUNCT_INSIDE_WORD = frozenset([".", "'", "‘", "´", "’", HYPHEN, EN_DASH])
 PUNCT_ENDING_WORD = frozenset(["'", "²", "³"])
 # Punctuation symbols that may occur together
 PUNCT_COMBINATIONS = frozenset(["?", "!", "…"])
+# Punctuation in end of indirect speech that doesn't necessarily end sentences
+PUNCT_INDIRECT_SPEECH = frozenset(["?", "!"])
+
 
 # Single and double quotes
 SQUOTES = "'‚‛‘´"
@@ -204,7 +211,13 @@ CLOCK_ABBREVS = frozenset(("kl", "kl.", "klukkan"))
 TELNO_PREFIXES = "45678"
 
 # Known telephone country codes
-COUNTRY_CODES = frozenset(("354", "+354", "00354",))
+COUNTRY_CODES = frozenset(
+    (
+        "354",
+        "+354",
+        "00354",
+    )
+)
 
 # Words that can precede a year number; will be assimilated into the year token
 YEAR_WORD = frozenset(("árið", "ársins", "árinu"))
@@ -516,9 +529,9 @@ DIRECTIONS = {
     "N": "Norður",
 }
 
-_unit_lambda: Callable[[str], str] = lambda unit: unit + r"(?!\w)" if unit[
-    -1
-].isalpha() else unit
+_unit_lambda: Callable[[str], str] = (
+    lambda unit: unit + r"(?!\w)" if unit[-1].isalpha() else unit
+)
 
 SI_UNITS_SET: FrozenSet[str] = frozenset(SI_UNITS.keys())
 SI_UNITS_REGEX_STRING = r"|".join(
@@ -627,7 +640,7 @@ ROMAN_NUMERAL_MAP = tuple(
 
 
 def roman_to_int(s: str) -> int:
-    """ Quick and dirty conversion of an already validated Roman numeral to integer """
+    """Quick and dirty conversion of an already validated Roman numeral to integer"""
     # Adapted from http://code.activestate.com/recipes/81611-roman-numerals/
     i = result = 0
     for integer, numeral in ROMAN_NUMERAL_MAP:
@@ -636,6 +649,7 @@ def roman_to_int(s: str) -> int:
             i += len(numeral)
     assert i == len(s)
     return result
+
 
 NUMBER_ABBREV = {
     "þús.": 1000,
@@ -1147,7 +1161,7 @@ KT_MAGIC = [3, 2, 7, 6, 5, 4, 0, 3, 2]
 
 
 def valid_ssn(kt: str) -> bool:
-    """ Validate Icelandic social security number """
+    """Validate Icelandic social security number"""
     if not kt or len(kt) != 11 or kt[6] != "-":
         return False
     m = 11 - sum((ord(kt[i]) - 48) * KT_MAGIC[i] for i in range(9)) % 11

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1675,7 +1675,7 @@ class PunctuationParser:
                 dots, rt = rt.split(2)
                 yield TOK.Punctuation(dots, normalized=".")
             elif rtxt.startswith(",,"):
-                if rtxt[2:3].isalpha():
+                if rtxt[2:3].isalnum():
                     # Probably someone trying to type opening double quotes with commas
                     punct, rt = rt.split(2)
                     yield TOK.Punctuation(punct, normalized="„")
@@ -2467,7 +2467,7 @@ def parse_sentences(token_stream: Iterator[Tok]) -> Iterator[Tok]:
                     yield token
                     token = next_token
                     next_token = next(token_stream)
-                    if next_token.txt.isalnum() and next_token.txt.islower():
+                    if next_token.txt.islower():
                         # Probably indirect speech
                         # „Er einhver þarna?“ sagði konan.
                         yield token

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -2468,6 +2468,7 @@ def parse_sentences(token_stream: Iterator[Tok]) -> Iterator[Tok]:
                 ):
                     yield token
                     token = next_token
+                    next_token = next(token_stream)
                     if next_token.txt.isalnum() and next_token.txt.islower():
                         # Probably indirect speech
                         # „Er einhver þarna?“ sagði konan.

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -2357,6 +2357,11 @@ def test_split_sentences() -> None:
     assert len(sents) == 1
     assert sents == ["„ Hún hló , “ sagði barnið ."]
 
+    # g = t.split_into_sentences("„Hvað meinarðu??“ sagði barnið.")
+    # sents = list(g)
+    # assert len(sents) == 1
+    # assert sents == ["„ Hvað meinarðu ?? “ sagði barnið ."]
+
 
 def test_normalization() -> None:
     text, norm = get_text_and_norm('Hann sagði: "Þú ert ágæt!".')

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -2341,6 +2341,22 @@ def test_split_sentences() -> None:
     # ]
     # Test onesentperline
 
+    # Test whether indirect speech is split up
+    g = t.split_into_sentences("„Er einhver þarna?“ sagði konan.")
+    sents = list(g)
+    assert len(sents) == 1
+    assert sents == ["„ Er einhver þarna ? “ sagði konan ."]
+
+    g = t.split_into_sentences("„Er einhver þarna?“ Maðurinn þorði varla fram.")
+    sents = list(g)
+    assert len(sents) == 2
+    assert sents == ["„ Er einhver þarna ? “", "Maðurinn þorði varla fram ."]
+
+    g = t.split_into_sentences("„Hún hló,“ sagði barnið.")
+    sents = list(g)
+    assert len(sents) == 1
+    assert sents == ["„ Hún hló , “ sagði barnið ."]
+
 
 def test_normalization() -> None:
     text, norm = get_text_and_norm('Hann sagði: "Þú ert ágæt!".')

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -58,6 +58,11 @@ def strip_originals(tokens: List[Tok]) -> List[Tok]:
     return tokens
 
 
+def get_text_and_norm(orig: str) -> Tuple[str, str]:
+    toklist = list(t.tokenize(orig))
+    return t.text_from_tokens(toklist), t.normalized_text_from_tokens(toklist)
+
+
 def test_single_tokens() -> None:
 
     TEST_CASES = [
@@ -2319,16 +2324,12 @@ def test_split_sentences() -> None:
     g = t.split_into_sentences("Athugum [hvort [setningin sé rétt skilin]].")
     sents = list(g)
     assert len(sents) == 1
-    assert sents == [
-        "Athugum [ hvort [ setningin sé rétt skilin ] ] ."
-    ]
+    assert sents == ["Athugum [ hvort [ setningin sé rétt skilin ] ] ."]
 
     g = t.split_into_sentences("Þessi [ætti [líka að]] vera rétt skilin.")
     sents = list(g)
     assert len(sents) == 1
-    assert sents == [
-        "Þessi [ ætti [ líka að ] ] vera rétt skilin ."
-    ]
+    assert sents == ["Þessi [ ætti [ líka að ] ] vera rétt skilin ."]
 
     # g = t.split_into_sentences("Þessi á [[líka að]] vera rétt skilin.")
     # sents = list(g)
@@ -2342,9 +2343,58 @@ def test_split_sentences() -> None:
 
 
 def test_normalization() -> None:
-    toklist = list(t.tokenize('Hann sagði: "Þú ert ágæt!".'))
-    assert t.text_from_tokens(toklist) == 'Hann sagði : " Þú ert ágæt ! " .'
-    assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt ! “ ."
+    text, norm = get_text_and_norm('Hann sagði: "Þú ert ágæt!".')
+
+    assert text == 'Hann sagði : " Þú ert ágæt ! " .'
+    assert norm == "Hann sagði : „ Þú ert ágæt ! “ ."
+
+    text, norm = get_text_and_norm("Hún vinnur í fjármála-og efnahagsráðuneytinu.")
+    assert text == "Hún vinnur í fjármála- og efnahagsráðuneytinu ."
+    assert norm == "Hún vinnur í fjármála- og efnahagsráðuneytinu ."
+
+    text, norm = get_text_and_norm("Þetta er tyrfið...")
+    assert text == "Þetta er tyrfið ..."
+    assert norm == "Þetta er tyrfið …"
+
+    text, norm = get_text_and_norm("Þetta er gaman..")
+    assert text == "Þetta er gaman .."
+    assert norm == "Þetta er gaman ."
+
+    text, norm = get_text_and_norm("Þetta er hvellur.....")
+    assert text == "Þetta er hvellur ....."
+    assert norm == "Þetta er hvellur …"
+
+    text, norm = get_text_and_norm("Þetta er mergjað………")
+    assert text == "Þetta er mergjað ………"
+    assert norm == "Þetta er mergjað …"
+
+    text, norm = get_text_and_norm("Haldið var áfram [...] eftir langt hlé.")
+    assert text == "Haldið var áfram [...] eftir langt hlé ."
+    assert norm == "Haldið var áfram […] eftir langt hlé ."
+
+    text, norm = get_text_and_norm("Þetta er tyrfið,, en við höldum áfram.")
+    assert text == "Þetta er tyrfið ,, en við höldum áfram ."
+    assert norm == "Þetta er tyrfið , en við höldum áfram ."
+
+    text, norm = get_text_and_norm('Hinn svokallaði ,,Galileóhestur" hvarf.')
+    assert text == 'Hinn svokallaði ,, Galileóhestur " hvarf .'
+    assert norm == "Hinn svokallaði „ Galileóhestur “ hvarf ."
+
+    text, norm = get_text_and_norm("Mars - hin rauða pláneta - skín bjart í nótt.")
+    assert text == "Mars - hin rauða pláneta - skín bjart í nótt ."
+    assert norm == "Mars - hin rauða pláneta - skín bjart í nótt ."
+
+    text, norm = get_text_and_norm("Mars – hin rauða pláneta – skín bjart í nótt.")
+    assert text == "Mars – hin rauða pláneta – skín bjart í nótt ."
+    assert norm == "Mars - hin rauða pláneta - skín bjart í nótt ."
+
+    text, norm = get_text_and_norm("Mars — hin rauða pláneta — skín bjart í nótt.")
+    assert text == "Mars — hin rauða pláneta — skín bjart í nótt ."
+    assert norm == "Mars - hin rauða pláneta - skín bjart í nótt ."
+
+    text, norm = get_text_and_norm("Hvernig gastu gert þetta???!!!!!")
+    assert text == "Hvernig gastu gert þetta ???!!!!!"
+    assert norm == "Hvernig gastu gert þetta ?"
 
 
 def test_abbr_at_eos() -> None:


### PR DESCRIPTION
- Two periods normalized to one
- More than 4 punctuation marks normalized to the first one
- one_sent_per_line function reverted, original handles it
- Support for indirect speech added, preventing sentence splitting in the middle
- Test cases added for punctuation normalization and indirect speech

Attn.: Built on thhe [ospl branch, ](https://github.com/mideind/Tokenizer/pull/38), view that pull request first