### PR TITLE
Refactoring raw token generation to better support long input text.

### DIFF
--- a/src/tokenizer/definitions.py
+++ b/src/tokenizer/definitions.py
@@ -139,8 +139,8 @@ UNICODE_REGEX = re.compile(
 
 # Used for the first step of token splitting
 ROUGH_TOKEN_REGEX = re.compile(r"(\s*)([^\s]*)", re.UNICODE)
-# Variables for readability when using the ROUGH_TOKEN_REGEX
-ROUGH_TOKEN_REGEX_ALL_GROUPS = 0
+# Constants for readability when using the ROUGH_TOKEN_REGEX
+ROUGH_TOKEN_REGEX_ENTIRE_MATCH = 0
 ROUGH_TOKEN_REGEX_WHITE_SPACE_GROUP = 1
 ROUGH_TOKEN_REGEX_TOKEN_GROUP = 2
 

--- a/src/tokenizer/definitions.py
+++ b/src/tokenizer/definitions.py
@@ -139,6 +139,10 @@ UNICODE_REGEX = re.compile(
 
 # Used for the first step of token splitting
 ROUGH_TOKEN_REGEX = re.compile(r"(\s*)([^\s]*)", re.UNICODE)
+# Variables for readability when using the ROUGH_TOKEN_REGEX
+ROUGH_TOKEN_REGEX_ALL_GROUPS = 0
+ROUGH_TOKEN_REGEX_WHITE_SPACE_GROUP = 1
+ROUGH_TOKEN_REGEX_TOKEN_GROUP = 2
 
 # Hyphens are normalized to '-'
 HYPHEN = "-"  # Normal hyphen

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -38,9 +38,23 @@
 
 """
 
-from typing import (Any, Callable, Deque, FrozenSet, Iterable, Iterator, List,
-                    Mapping, Match, Optional, Tuple, Type, TypeVar, Union,
-                    cast)
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    FrozenSet,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Match,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import datetime
 import re
@@ -60,6 +74,7 @@ EXCLAMATIONS = frozenset(("!", "?"))
 # Global variables for readability
 SPAN_START = 0
 SPAN_END = 1
+
 
 class Tok:
 
@@ -183,7 +198,13 @@ class Tok:
 
         if self.origin_spans is not None and self.original is not None:
             if pos >= len(self.origin_spans):
-                l = Tok(self.kind, self.txt, self.val, self.original, self.origin_spans)
+                l = Tok(
+                    self.kind,
+                    self.txt,
+                    self.val,
+                    self.original,
+                    self.origin_spans,
+                )
                 r = Tok(self.kind, "", None, "", [])
             else:
                 l = Tok(
@@ -266,7 +287,11 @@ class Tok:
             self.substitute((i, i + len(old_str)), new_char)
 
     def concatenate(
-        self, other: "Tok", *, separator: str = "", metadata_from_other: bool = False
+        self,
+        other: "Tok",
+        *,
+        separator: str = "",
+        metadata_from_other: bool = False,
     ) -> "Tok":
         """Return a new token that consists of self with other
         concatenated to the end.
@@ -808,7 +833,9 @@ class TOK:
 
     @staticmethod
     def Begin_Sentence(
-        t: Optional[Tok] = None, num_parses: int = 0, err_index: Optional[int] = None
+        t: Optional[Tok] = None,
+        num_parses: int = 0,
+        err_index: Optional[int] = None,
     ) -> Tok:
         if t is None:
             return Tok(TOK.S_BEGIN, None, (num_parses, err_index))
@@ -1380,8 +1407,12 @@ def generate_rough_tokens_from_tok(tok: Tok) -> Iterator[Tok]:
         assert match is not None
         # Since the match indexes the text of the original token,
         # we need to shift the indices so that they match the current token.
-        shifted_all_group_span = shift_span(match.span(ROUGH_TOKEN_REGEX_ALL_GROUPS), -pos)
-        shifted_white_space_span = shift_span(match.span(ROUGH_TOKEN_REGEX_WHITE_SPACE_GROUP), -pos)
+        shifted_all_group_span = shift_span(
+            match.span(ROUGH_TOKEN_REGEX_ALL_GROUPS), -pos
+        )
+        shifted_white_space_span = shift_span(
+            match.span(ROUGH_TOKEN_REGEX_WHITE_SPACE_GROUP), -pos
+        )
         # Then we split the current token using the shifted spans
         small_tok, tok = tok.split(shifted_all_group_span[SPAN_END])
         # Remove whitespace from the start of the token
@@ -1520,7 +1551,9 @@ def generate_raw_tokens(
 
 
 def could_be_end_of_sentence(
-    next_token: Tok, test_set: FrozenSet[int] = TOK.TEXT, multiplier: bool = False
+    next_token: Tok,
+    test_set: FrozenSet[int] = TOK.TEXT,
+    multiplier: bool = False,
 ) -> bool:
     """Return True if next_token could be ending the current sentence or
     starting the next one"""
@@ -2187,7 +2220,10 @@ def parse_particles(token_stream: Iterator[Tok], **options: Any) -> Iterator[Tok
                         a = "{0:.2f}".format(next_token.number).split(".")
                         h, m = int(a[0]), int(a[1])
                         token = TOK.Time(
-                            token.concatenate(next_token, separator=" "), h, m, 0
+                            token.concatenate(next_token, separator=" "),
+                            h,
+                            m,
+                            0,
                         )
                     else:
                         # next_token.kind is TOK.TIME
@@ -2323,7 +2359,9 @@ def parse_particles(token_stream: Iterator[Tok], **options: Any) -> Iterator[Tok
                     )
                 else:
                     token = TOK.Measurement(
-                        token.concatenate(next_token, separator=" "), unit, value
+                        token.concatenate(next_token, separator=" "),
+                        unit,
+                        value,
                     )
                 next_token = next(token_stream)
 
@@ -2522,9 +2560,10 @@ def parse_sentences(token_stream: Iterator[Tok]) -> Iterator[Tok]:
                         token = tok_end_sentence
                         in_sentence = False
                 if token.punctuation in END_OF_SENTENCE and not (
-                    token.punctuation
-                    == "…"  # Excluding sentences with ellipsis in the middle
-                    and not could_be_end_of_sentence(next_token)
+                    token.punctuation == "…"
+                    and not could_be_end_of_sentence(
+                        next_token
+                    )  # Excluding sentences with ellipsis in the middle
                 ):
                     # Combining punctuation ('??!!!')
                     while (
@@ -2632,7 +2671,8 @@ def parse_phrases_1(token_stream: Iterator[Tok]) -> Iterator[Tok]:
                     # the abbreviation "gr.", we assume that the only
                     # interpretation of the abbreviation is "grein".
                     next_token = TOK.Word(
-                        next_token, [BIN_Tuple("grein", 0, "kvk", "skst", "gr.", "-")]
+                        next_token,
+                        [BIN_Tuple("grein", 0, "kvk", "skst", "gr.", "-")],
                     )
 
                 month = month_for_token(next_token, True)
@@ -2927,7 +2967,8 @@ def parse_phrases_2(
                     if percentage is not None:
                         # We have '17 prósent': coalesce into a single token
                         token = TOK.Percent(
-                            token.concatenate(next_token, separator=" "), token.number
+                            token.concatenate(next_token, separator=" "),
+                            token.number,
                         )
                         # Eat the percent word token
                         next_token = next(token_stream)

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -2490,7 +2490,15 @@ def test_html_escapes() -> None:
         Tok(kind=11002, txt=None, val=None),
     ]
     assert toklist == correct
-
+    toklist = list(
+        t.tokenize(
+            # En space and Em space
+            "Ég&#8194;fór &aacute; &lt;bömmer&gt;&#8195;og bor&shy;ðaði köku.",
+            replace_html_escapes=True,
+        )
+    )
+    toklist = strip_originals(toklist)
+    assert toklist == correct
     toklist = list(
         t.tokenize(
             "Ég fór &uacute;t og &#97;fs&#x61;kaði mig", replace_html_escapes=True

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -31,11 +31,10 @@
 
 """
 
-from typing import Any, Iterable, Iterator, List, Union, Tuple, cast
+from typing import Any, Iterable, Iterator, List, Tuple, Union, cast
 
 import tokenizer as t
 from tokenizer.definitions import BIN_Tuple, ValType
-
 
 TOK = t.TOK
 Tok = t.Tok
@@ -2425,12 +2424,12 @@ def test_normalization() -> None:
     assert t.text_from_tokens(toklist) == 'Hann sagði : ,, Þú ert ágæt ??!? " .'
     assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt ? “ ."
 
-    toklist = list(t.tokenize('Jón,, farðu út.'))
-    assert t.text_from_tokens(toklist) == 'Jón ,, farðu út .'
+    toklist = list(t.tokenize("Jón,, farðu út."))
+    assert t.text_from_tokens(toklist) == "Jón ,, farðu út ."
     assert t.normalized_text_from_tokens(toklist) == "Jón , farðu út ."
 
-    toklist = list(t.tokenize('Jón ,,farðu út.'))
-    assert t.text_from_tokens(toklist) == 'Jón ,, farðu út .'
+    toklist = list(t.tokenize("Jón ,,farðu út."))
+    assert t.text_from_tokens(toklist) == "Jón ,, farðu út ."
     assert t.normalized_text_from_tokens(toklist) == "Jón „ farðu út ."
 
     toklist = list(t.tokenize('Hann sagði: ,,Þú ert ágæt.....".'))
@@ -2440,7 +2439,6 @@ def test_normalization() -> None:
     toklist = list(t.tokenize('Hann sagði: ,,Þú ert ágæt…..".'))
     assert t.text_from_tokens(toklist) == 'Hann sagði : ,, Þú ert ágæt ….. " .'
     assert t.normalized_text_from_tokens(toklist) == "Hann sagði : „ Þú ert ágæt … “ ."
-
 
 
 def test_abbr_at_eos() -> None:

--- a/test/test_tokenizer_tok.py
+++ b/test/test_tokenizer_tok.py
@@ -150,27 +150,71 @@ def test_substitute_bugfix_1() -> None:
     test_string = "xya" + ACCENT + "zu" + ACCENT + "w&aacute;o" + UMLAUT + "b"
     #              012    3         45    6         7890123456    7         8
     #              0123456789012345
-    t = Tok(kind=-1, txt=test_string, val=None, original=test_string, origin_spans=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
+    t = Tok(
+        kind=-1,
+        txt=test_string,
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    )
     t.substitute((2, 4), "á")
-    assert t == Tok(kind=-1, txt="xyázu" + ACCENT + "w&aacute;o" + UMLAUT + "b", val=None, original=test_string, origin_spans=[0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
+    assert t == Tok(
+        kind=-1,
+        txt="xyázu" + ACCENT + "w&aacute;o" + UMLAUT + "b",
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    )
 
     t.substitute((4, 6), "ú")
-    assert t == Tok(kind=-1, txt="xyázúw&aacute;o" + UMLAUT + "b", val=None, original=test_string, origin_spans=[0, 1, 2, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])
+    assert t == Tok(
+        kind=-1,
+        txt="xyázúw&aacute;o" + UMLAUT + "b",
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    )
 
     t.substitute((14, 16), "ö")
-    assert t == Tok(kind=-1, txt="xyázúw&aacute;öb", val=None, original=test_string, origin_spans=[0, 1, 2, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18])
+    assert t == Tok(
+        kind=-1,
+        txt="xyázúw&aacute;öb",
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18],
+    )
 
     # bug was here
     t.substitute((6, 14), "á")
-    assert t == Tok(kind=-1, txt="xyázúwáöb", val=None, original=test_string, origin_spans=[0, 1, 2, 4, 5, 7, 8, 16, 18])
+    assert t == Tok(
+        kind=-1,
+        txt="xyázúwáöb",
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 4, 5, 7, 8, 16, 18],
+    )
 
 
 def test_multiple_substitutions() -> None:
-    t = Tok(TOK.RAW, "a&123b&456&789c", None, "a&123b&456&789c", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+    t = Tok(
+        TOK.RAW,
+        "a&123b&456&789c",
+        None,
+        "a&123b&456&789c",
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    )
     t.substitute((1, 5), "x")
-    assert t == Tok(TOK.RAW, "axb&456&789c", None, "a&123b&456&789c", [0, 1, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+    assert t == Tok(
+        TOK.RAW,
+        "axb&456&789c",
+        None,
+        "a&123b&456&789c",
+        [0, 1, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    )
     t.substitute((3, 7), "y")
-    assert t == Tok(TOK.RAW, "axby&789c", None, "a&123b&456&789c", [0, 1, 5, 6, 10, 11, 12, 13, 14])
+    assert t == Tok(
+        TOK.RAW, "axby&789c", None, "a&123b&456&789c", [0, 1, 5, 6, 10, 11, 12, 13, 14]
+    )
     t.substitute((4, 8), "z")
     assert t == Tok(TOK.RAW, "axbyzc", None, "a&123b&456&789c", [0, 1, 5, 6, 10, 14])
 
@@ -255,7 +299,13 @@ def test_html_escapes_with_origin_tracking() -> None:
     test_string = "xy&#x61;z&aacute;w&#97;b"
     tokens = list(tokenizer.generate_raw_tokens(test_string, replace_html_escapes=True))
     assert len(tokens) == 1
-    assert tokens[0] == Tok(kind=TOK.RAW, txt="xyazáwab", val=None, original=test_string, origin_spans=[0, 1, 2, 8, 9, 17, 18, 23])
+    assert tokens[0] == Tok(
+        kind=TOK.RAW,
+        txt="xyazáwab",
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 8, 9, 17, 18, 23],
+    )
     # Note the space after &nbsp;
     test_string = "Ég&nbsp; fór út."
     #              0101234567890123
@@ -264,7 +314,13 @@ def test_html_escapes_with_origin_tracking() -> None:
     assert len(tokens) == 3
     assert tokens == [
         Tok(kind=TOK.RAW, txt="Ég", val=None, original="Ég", origin_spans=[0, 1]),
-        Tok(kind=TOK.RAW, txt="fór", val=None, original="&nbsp; fór", origin_spans=[7, 8, 9]),
+        Tok(
+            kind=TOK.RAW,
+            txt="fór",
+            val=None,
+            original="&nbsp; fór",
+            origin_spans=[7, 8, 9],
+        ),
         Tok(kind=TOK.RAW, txt="út.", val=None, original=" út.", origin_spans=[1, 2, 3]),
     ]
     test_string = "Ég&nbsp;&nbsp;fór út."
@@ -274,7 +330,13 @@ def test_html_escapes_with_origin_tracking() -> None:
     assert len(tokens) == 3
     assert tokens == [
         Tok(kind=TOK.RAW, txt="Ég", val=None, original="Ég", origin_spans=[0, 1]),
-        Tok(kind=TOK.RAW, txt="fór", val=None, original="&nbsp;&nbsp;fór", origin_spans=[12, 13, 14]),
+        Tok(
+            kind=TOK.RAW,
+            txt="fór",
+            val=None,
+            original="&nbsp;&nbsp;fór",
+            origin_spans=[12, 13, 14],
+        ),
         Tok(kind=TOK.RAW, txt="út.", val=None, original=" út.", origin_spans=[1, 2, 3]),
     ]
     test_string = "Ég&nbsp;fór&nbsp;út."
@@ -284,8 +346,20 @@ def test_html_escapes_with_origin_tracking() -> None:
     assert len(tokens) == 3
     assert tokens == [
         Tok(kind=TOK.RAW, txt="Ég", val=None, original="Ég", origin_spans=[0, 1]),
-        Tok(kind=TOK.RAW, txt="fór", val=None, original="&nbsp;fór", origin_spans=[6, 7, 8]),
-        Tok(kind=TOK.RAW, txt="út.", val=None, original="&nbsp;út.", origin_spans=[6, 7, 8]),
+        Tok(
+            kind=TOK.RAW,
+            txt="fór",
+            val=None,
+            original="&nbsp;fór",
+            origin_spans=[6, 7, 8],
+        ),
+        Tok(
+            kind=TOK.RAW,
+            txt="út.",
+            val=None,
+            original="&nbsp;út.",
+            origin_spans=[6, 7, 8],
+        ),
     ]
     test_string = "Ég fór út.&nbsp;"
     #              0101230123012345
@@ -312,24 +386,46 @@ def test_html_escapes_with_origin_tracking() -> None:
 
 def test_unicode_escapes_with_origin_tracking() -> None:
     test_string = "xya" + ACCENT + "zu" + ACCENT + "wo" + UMLAUT + "b"
-    tokens = list(tokenizer.generate_raw_tokens(test_string, replace_composite_glyphs=True))
+    tokens = list(
+        tokenizer.generate_raw_tokens(test_string, replace_composite_glyphs=True)
+    )
     assert len(tokens) == 1
-    assert tokens[0] == Tok(kind=TOK.RAW, txt="xyázúwöb", val=None, original=test_string, origin_spans=[0, 1, 2, 4, 5, 7, 8, 10])
+    assert tokens[0] == Tok(
+        kind=TOK.RAW,
+        txt="xyázúwöb",
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 4, 5, 7, 8, 10],
+    )
 
 
 def test_unicode_escapes_that_are_removed() -> None:
     test_string = "a\xadb\xadc"
-    tokens = list(tokenizer.generate_raw_tokens(test_string, replace_composite_glyphs=True))
+    tokens = list(
+        tokenizer.generate_raw_tokens(test_string, replace_composite_glyphs=True)
+    )
     assert len(tokens) == 1
-    assert tokens[0] == Tok(kind=TOK.RAW, txt="abc", val=None, original=test_string, origin_spans=[0, 2, 4])
+    assert tokens[0] == Tok(
+        kind=TOK.RAW, txt="abc", val=None, original=test_string, origin_spans=[0, 2, 4]
+    )
 
 
 def test_html_unicode_mix() -> None:
     test_string = "xya" + ACCENT + "zu" + ACCENT + "w&aacute;o" + UMLAUT + "b"
     #              012    3         45    6         7890123456    7         8
-    tokens = list(tokenizer.generate_raw_tokens(test_string, replace_composite_glyphs=True, replace_html_escapes=True))
+    tokens = list(
+        tokenizer.generate_raw_tokens(
+            test_string, replace_composite_glyphs=True, replace_html_escapes=True
+        )
+    )
     assert len(tokens) == 1
-    assert tokens[0] == Tok(kind=TOK.RAW, txt="xyázúwáöb", val=None, original=test_string, origin_spans=[0, 1, 2, 4, 5, 7, 8, 16, 18])
+    assert tokens[0] == Tok(
+        kind=TOK.RAW,
+        txt="xyázúwáöb",
+        val=None,
+        original=test_string,
+        origin_spans=[0, 1, 2, 4, 5, 7, 8, 16, 18],
+    )
 
 
 def test_tok_concatenation() -> None:
@@ -337,7 +433,9 @@ def test_tok_concatenation() -> None:
     tok1 = Tok(TOK.RAW, str1, None, str1, list(range(len(str1))))
     str2 = "jklæ"
     tok2 = Tok(TOK.RAW, str2, None, str2, list(range(len(str1))))
-    assert tok1.concatenate(tok2) == Tok(TOK.RAW, str1 + str2, None, str1 + str2, list(range(len(str1 + str2))))
+    assert tok1.concatenate(tok2) == Tok(
+        TOK.RAW, str1 + str2, None, str1 + str2, list(range(len(str1 + str2)))
+    )
 
     str1 = "abc"
     or1 = "&123&456&789"
@@ -345,7 +443,9 @@ def test_tok_concatenation() -> None:
     or2 = "&xx&yy&zz"
     tok1 = Tok(TOK.RAW, str1, None, or1, [0, 4, 8])
     tok2 = Tok(TOK.RAW, str2, None, or2, [0, 2, 4])
-    assert tok1.concatenate(tok2) == Tok(TOK.RAW, str1 + str2, None, or1 + or2, [0, 4, 8, 12, 14, 16])
+    assert tok1.concatenate(tok2) == Tok(
+        TOK.RAW, str1 + str2, None, or1 + or2, [0, 4, 8, 12, 14, 16]
+    )
 
 
 def test_tok_concatenation_with_separator() -> None:
@@ -354,7 +454,13 @@ def test_tok_concatenation_with_separator() -> None:
     str2 = "jklæ"
     tok2 = Tok(TOK.RAW, str2, None, str2, list(range(len(str1))))
     sep = "WOLOLO"
-    assert tok1.concatenate(tok2, separator=sep) == Tok(TOK.RAW, str1 + sep + str2, None, str1 + str2, [0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 5, 6, 7])
+    assert tok1.concatenate(tok2, separator=sep) == Tok(
+        TOK.RAW,
+        str1 + sep + str2,
+        None,
+        str1 + str2,
+        [0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 5, 6, 7],
+    )
 
     str1 = "abc"
     or1 = "&123&456&789"
@@ -363,7 +469,13 @@ def test_tok_concatenation_with_separator() -> None:
     tok1 = Tok(TOK.RAW, str1, None, or1, [0, 4, 8])
     tok2 = Tok(TOK.RAW, str2, None, or2, [0, 2, 4])
     sep = "WOLOLO"
-    assert tok1.concatenate(tok2, separator=sep) == Tok(TOK.RAW, str1 + sep + str2, None, or1 + or2, [0, 4, 8, 12, 12, 12, 12, 12, 12, 12, 14, 16])
+    assert tok1.concatenate(tok2, separator=sep) == Tok(
+        TOK.RAW,
+        str1 + sep + str2,
+        None,
+        or1 + or2,
+        [0, 4, 8, 12, 12, 12, 12, 12, 12, 12, 14, 16],
+    )
 
 
 def test_tok_substitute_all() -> None:
@@ -386,7 +498,13 @@ def test_tok_substitute_all() -> None:
     #    01234567890123456789
     t = Tok(TOK.RAW, s, None, s, list(range(len(s))))
     t.substitute_all("r", "")
-    assert t == Tok(TOK.RAW, "Þessi veðu lengi.", None, s, [0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 12, 13, 14, 15, 16, 18, 19])
+    assert t == Tok(
+        TOK.RAW,
+        "Þessi veðu lengi.",
+        None,
+        s,
+        [0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 12, 13, 14, 15, 16, 18, 19],
+    )
 
 
 def test_tok_substitute_longer() -> None:


### PR DESCRIPTION
This fixes the issue raised in #40 

To fix the issue it was best to change how we break the text into raw tokens.
In short, instead of splitting raw tokens off the tok_big, which is O(N^2) w.r.t. the text input length due to the copying, we keep track of the index of the text we have processed and only take slices of the text necessary for the next raw token.

The original code did all the HTML escapes removal and Unicode composite glyph on the tok_big, now we do that on each individual token. This opened up the possibility that some of the raw tokens contain white spaces which we need to further handle.

These are the speed testing results which first demonstrated the problem and we can now see that the problem is gone.
```
Running test with 20 words and 40 sentences in each line and 300 lines.
number of sentences encountered: 12000
time taken: 3.401460647583008
0.000283 seconds per sentence

Running test with 20 words and 1 sentences in each line and 12000 lines.
number of sentences encountered: 12000
time taken: 3.706263303756714
0.000309 seconds per sentence

Running test with 20 words and 12000 sentences in each line and 1 lines.
number of sentences encountered: 12000
time taken: 3.3535232543945312
0.000279 seconds per sentence
```