### PR TITLE
Fix/colon time correct spaces

### DIFF
--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -3233,8 +3233,8 @@ def correct_spaces(s: str) -> str:
                 and len(w) == 2
                 and len(r) >= 2
                 and r[-1] == ":"
-                and r[-2].strip().isnumeric()
-                and len(r[-2].strip()) in [1, 2]
+                and (p := r[-2].strip()).isnumeric()
+                and len(p) in {1, 2}
             )
         ):
             r.append(" " + w)

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -3223,7 +3223,20 @@ def correct_spaces(s: str) -> str:
             # "bensínstöðvar, -dælur og -tankar"
             r[-1] = " -"
             r.append(w)
-        elif TP_SPACE[last - 1][this - 1] and r:
+        elif (
+            TP_SPACE[last - 1][this - 1]
+            and r
+            and not (
+                # Special case for colon-separated time or duration
+                # such as "12:00", "3:15" or "37:02:29"
+                w.isnumeric()
+                and len(w) == 2
+                and len(r) >= 2
+                and r[-1] == ":"
+                and r[-2].strip().isnumeric()
+                and len(r[-2].strip()) in [1, 2]
+            )
+        ):
             r.append(" " + w)
         else:
             r.append(w)

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -1145,6 +1145,15 @@ def test_correct_spaces() -> None:
         "Þetta er setning.Þetta er önnur setning.Líka.En hvað með þetta?"
     )
     assert s == "Þetta er setning. Þetta er önnur setning. Líka. En hvað með þetta?"
+    # Test that colon-separated times are not space-separated
+    s = t.correct_spaces("Klukkan er 12: 00 og ég ætla að fara út .")
+    assert s == "Klukkan er 12:00 og ég ætla að fara út."
+    s = t.correct_spaces("Tíminn byrjar kl . 4: 14 og klukkan er núna 5:00 .")
+    assert s == "Tíminn byrjar kl. 4:14 og klukkan er núna 5:00."
+    s = t.correct_spaces("Veislan verður kl . 12 : 00 - 14 : 00.")
+    assert s == "Veislan verður kl. 12:00-14:00."
+    s = t.correct_spaces("Hún kom í mark á tímanum 3 : 59 : 04 ,rétt fyrir lokin.")
+    assert s == "Hún kom í mark á tímanum 3:59:04, rétt fyrir lokin."
 
 
 def test_abbrev() -> None:


### PR DESCRIPTION
Improved handling for colon-separated times and durations in `correct_spaces`. Added tests for this too.
Previously it added spaces after all colons resulting in wrong time formats, e.g. "kl. 9:40" -> "kl. 9: 40" and "3:40:15" -> "3: 40: 15".