### PR TITLE
Tweaks

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v4
@@ -27,8 +27,9 @@ jobs:
 
     - name: Install Tokenizer
       run: |
-        python -m pip install --upgrade pip wheel setuptools
-        python -m pip install -e ".[dev]"
+        python -m pip install --upgrade uv
+        uv pip install --system --upgrade wheel setuptools
+        uv pip install --system --e ".[dev]"
 
     - name: Type check with mypy (only on oldest supported Python version)
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         python -m pip install --upgrade uv
         uv pip install --system --upgrade wheel setuptools
-        uv pip install --system --e ".[dev]"
+        uv pip install --system ".[dev]"
 
     - name: Type check with mypy (only on oldest supported Python version)
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,10 @@ celerybeat-schedule
 venv
 ENV/
 p39
+p310
+p311
 p312
+p313
 
 # Spyder project settings
 .spyderproject

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2016-2024 Miðeind ehf.
+Copyright (C) 2016-2025 Miðeind ehf.
 Original author: Vilhjálmur Þorsteinsson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ filterwarnings = [
 
 [tool.ruff]
 line-length = 88
-#lint.select = ["ALL"]
-extend-select = ["E501"]
+#lint.select = ["ALL"] # We use default rules for now
+extend-select = ["E501"] # Complain about line length
 # Ignore specific rules
 # (we should aim to have these as few as possible)
 lint.ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,20 @@ filterwarnings = [
 
 [tool.ruff]
 line-length = 88
+#lint.select = ["ALL"]
+extend-select = ["E501"]
+# Ignore specific rules
+# (we should aim to have these as few as possible)
+lint.ignore = [
+    "F405", # 'F405: Name may be undefined, or defined from star imports: typing'
+    "E731", # 'E731: Do not assign a lambda expression, use a def'
+]
 
 [tool.black]
 line-length = 88
 
 [tool.isort]
 # This forces these imports to placed at the top
-known_future_library = ["__future__", "typing", "typing_extensions"]
+known_future_library = ["typing"]
 profile = "black"
 line_length = 88

--- a/src/tokenizer/__init__.py
+++ b/src/tokenizer/__init__.py
@@ -1,6 +1,6 @@
 """
 
-    Copyright(C) 2016-2024 Miðeind ehf.
+    Copyright(C) 2016-2025 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -63,7 +63,7 @@ from .tokenizer import (
 from .abbrev import Abbreviations, ConfigError
 
 __author__ = "Miðeind ehf."
-__copyright__ = "(C) 2016-2024 Miðeind ehf."
+__copyright__ = "(C) 2016-2025 Miðeind ehf."
 __version__ = importlib.metadata.version(__name__)
 
 __all__ = (

--- a/src/tokenizer/abbrev.py
+++ b/src/tokenizer/abbrev.py
@@ -2,7 +2,7 @@
 
     Abbreviations module for tokenization of Icelandic text
 
-    Copyright (C) 2016-2024 Miðeind ehf.
+    Copyright (C) 2016-2025 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -303,7 +303,7 @@ class Abbreviations:
         Abbreviations.NOT_ABBREVIATIONS.add(s[1:-1])
 
     @staticmethod
-    def initialize():
+    def initialize() -> None:
         """Read the abbreviations config file"""
         with Abbreviations._lock:
             if len(Abbreviations.DICT):

--- a/src/tokenizer/definitions.py
+++ b/src/tokenizer/definitions.py
@@ -1182,7 +1182,7 @@ KT_MAGIC = [3, 2, 7, 6, 5, 4, 0, 3, 2]
 
 
 def valid_ssn(kt: str) -> bool:
-    """Validate Icelandic social security number"""
+    """Validate Icelandic social security number ("kennitala")"""
     if not kt or len(kt) != 11 or kt[6] != "-":
         return False
     m = 11 - sum((ord(kt[i]) - 48) * KT_MAGIC[i] for i in range(9)) % 11

--- a/src/tokenizer/definitions.py
+++ b/src/tokenizer/definitions.py
@@ -2,7 +2,7 @@
 
     Definitions used for tokenization of Icelandic text
 
-    Copyright (C) 2016-2024 Miðeind ehf.
+    Copyright (C) 2016-2025 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:

--- a/src/tokenizer/main.py
+++ b/src/tokenizer/main.py
@@ -3,7 +3,7 @@
 
     Tokenizer for Icelandic text
 
-    Copyright (C) 2016-2024 Miðeind ehf.
+    Copyright (C) 2016-2025 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -165,9 +165,9 @@ def main() -> None:
         backslashes and double quotes escaped with a backslash"""
         return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
-    def spanquote(l: list[int]) -> str:
-        """Return the list l as a string within double quotes"""
-        return '"' + "-".join(str(x) for x in l) + '"'
+    def spanquote(lst: list[int]) -> str:
+        """Return the list lst as a string within double quotes"""
+        return '"' + "-".join(str(x) for x in lst) + '"'
 
     def gen(f: TextIO) -> Iterator[str]:
         """Generate the lines of text in the input file"""

--- a/src/tokenizer/main.py
+++ b/src/tokenizer/main.py
@@ -167,7 +167,7 @@ def main() -> None:
     """Main function, called when the tokenize command is invoked"""
 
     args = parser.parse_args()
-    options: dict[str, bool] = dict()
+    options: dict[str, bool] = {}
 
     def quote(s: str) -> str:
         """Return the string s within double quotes, and with any contained
@@ -284,7 +284,7 @@ def main() -> None:
                 print('0,"","","",""', file=args.outfile)
         elif args.json:
             # Output the tokens in JSON format, one line per token
-            d: dict[str, Union[str, list[int]]] = dict(k=TOK.descr[t.kind])
+            d: dict[str, Union[str, list[int]]] = { "k": TOK.descr[t.kind] }
             if t.txt is not None:
                 d["t"] = t.txt
             v = val(t)

--- a/src/tokenizer/main.py
+++ b/src/tokenizer/main.py
@@ -44,6 +44,7 @@ from functools import partial
 
 from .definitions import AmountTuple, BIN_Tuple, NumberTuple, PunctuationTuple
 from .tokenizer import TOK, Tok, tokenize
+from . import __version__ as tokenizer_version
 
 
 ReadFile = argparse.FileType("r", encoding="utf-8")
@@ -151,6 +152,14 @@ parser.add_argument(
         "\t1: Ordinals returned as pure words.\n"
         "\t2: Ordinals returned as numbers."
     ),
+)
+
+parser.add_argument(
+    "-v",
+    "--version",
+    action="version",
+    version=f"%(prog)s {tokenizer_version}",
+    help="Show the version number and exit",
 )
 
 

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -358,7 +358,7 @@ class Tok:
         )
 
     def __repr__(self) -> str:
-        def quoted_string_repr(obj: Any) -> str:
+        def quoted_string_repr(obj: object) -> str:
             if isinstance(obj, str):
                 return f'"{obj}"'
             return str(obj)

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1508,7 +1508,7 @@ def generate_raw_tokens(
                     if replace_html_escapes:
                         # Replace HTML escapes: '&aacute;' -> 'á'
                         tok = html_replacement(tok)
-                    # HTML escapes and unicode possibly contain whitespace characters
+                    # HTML escapes and unicode may contain whitespace characters
                     # e.g. Em space '&#8195;' and non-breaking space '&nbsp;'
                     # Here we split those tokens into multiple tokens.
                     for small_tok in generate_rough_tokens_from_tok(tok):

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -2,7 +2,7 @@
 
     Tokenizer for Icelandic text
 
-    Copyright (C) 2016-2024 Miðeind ehf.
+    Copyright (C) 2016-2025 Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -59,7 +59,7 @@ import unicodedata  # type: ignore
 from collections import deque
 
 from .abbrev import Abbreviations
-from .definitions import *
+from .definitions import *   # noqa: F403
 
 _T = TypeVar("_T", bound="Tok")
 
@@ -119,6 +119,7 @@ class Tok:
     def punctuation(self) -> str:
         """Return the punctuation symbol associated with the
         token, if it is in fact a punctuation token"""
+
         if self.kind != TOK.PUNCTUATION:
             # This is not a punctuation token. In that case,
             # we return the Unicode 'unrecognized character'
@@ -189,28 +190,28 @@ class Tok:
         # txt=="" and original!=""?
         # TODO: What should we do with val?
 
-        l: Tok
-        r: Tok
+        ltk: Tok
+        rtk: Tok
 
         if self.origin_spans is not None and self.original is not None:
             if pos >= len(self.origin_spans):
-                l = Tok(
+                ltk = Tok(
                     self.kind,
                     self.txt,
                     self.val,
                     self.original,
                     self.origin_spans,
                 )
-                r = Tok(self.kind, "", None, "", [])
+                rtk = Tok(self.kind, "", None, "", [])
             else:
-                l = Tok(
+                ltk = Tok(
                     self.kind,
                     self.txt[:pos],
                     self.val,
                     self.original[: self.origin_spans[pos]],
                     self.origin_spans[:pos],
                 )
-                r = Tok(
+                rtk = Tok(
                     self.kind,
                     self.txt[pos:],
                     self.val,
@@ -218,10 +219,10 @@ class Tok:
                     [x - self.origin_spans[pos] for x in self.origin_spans[pos:]],
                 )
         else:
-            l = Tok(self.kind, self.txt[:pos], self.val)
-            r = Tok(self.kind, self.txt[pos:], self.val)
+            ltk = Tok(self.kind, self.txt[:pos], self.val)
+            rtk = Tok(self.kind, self.txt[pos:], self.val)
 
-        return l, r
+        return ltk, rtk
 
     def substitute(self, span: tuple[int, int], new: str) -> None:
         """Substitute a span with a single or empty character 'new'."""
@@ -254,7 +255,8 @@ class Tok:
 
             if len(tail) == 0:
                 # We're replacing the end of the string
-                # Can't pick the next element after the removed string since it doesn't exist
+                # Can't pick the next element after the removed
+                # string since it doesn't exist
                 # Use the length instead
                 new_origin = len(self.original)
             else:
@@ -343,7 +345,7 @@ class Tok:
             self.kind == other.kind and self.txt == other.txt and self.val == other.val
         )
 
-    def __eq__(self, o: Any) -> bool:
+    def __eq__(self, o: object) -> bool:
         """Full equality between two Tok instances"""
         if not isinstance(o, Tok):
             return False
@@ -359,8 +361,7 @@ class Tok:
         def quoted_string_repr(obj: Any) -> str:
             if isinstance(obj, str):
                 return f'"{obj}"'
-            else:
-                return str(obj)
+            return str(obj)
 
         return (
             f"Tok({self.kind}, {quoted_string_repr(self.txt)}, "
@@ -893,12 +894,12 @@ class TokenStream:
 
     def __getitem__(self, i: int) -> Optional[Tok]:
         if 0 <= i < self._max_lookahead:
-            l = len(self._lookahead)
+            llk = len(self._lookahead)
             try:
-                while l <= i:
+                while llk <= i:
                     # Extend deque to lookahead
                     self._lookahead.append(next(self._it))
-                    l += 1
+                    llk += 1
                 return self._lookahead[i]
             except StopIteration:
                 pass
@@ -1375,7 +1376,7 @@ def html_replacement(token: Tok) -> Tok:
 
 def generate_rough_tokens_from_txt(text: str) -> Iterator[Tok]:
     """Generate rough tokens from a string."""
-    # Rough tokens are tokens that are separated by white space, i.e. the regex (\\s*)."""
+    # Rough tokens are tokens that are separated by whitespace, i.e. the regex (\\s*).
     # pos tracks the index in the text we have covered so far.
     # We want to track pos, instead of treating text as a buffer,
     # since that would lead to a lot of unnecessary copying.
@@ -1391,12 +1392,12 @@ def generate_rough_tokens_from_txt(text: str) -> Iterator[Tok]:
 
 def generate_rough_tokens_from_tok(tok: Tok) -> Iterator[Tok]:
     """Generate rough tokens from a token."""
-    # Some tokens might have whitespace characters after we replace composite unicode glyphs
-    # and replace HTML escapes.
+    # Some tokens might have whitespace characters after we replace
+    # composite unicode glyphs and replace HTML escapes.
     # This function further splits those tokens into multiple tokens.
-    # Rough tokens are tokens that are separated by white space, i.e. the regex (\\s*)."""
+    # Rough tokens are tokens that are separated by white space, i.e. the regex (\\s*).
 
-    def shift_span(span: tuple[int, int], pos: int):
+    def shift_span(span: tuple[int, int], pos: int) -> tuple[int, int]:
         """Shift a span by a given amount"""
         return (span[SPAN_START] + pos, span[SPAN_END] + pos)
 
@@ -1462,13 +1463,14 @@ def generate_raw_tokens(
             saved = None
 
         # Force sentence splits
-        # Case 1: Two newlines with only whitespace between appear anywhere in 'big_text'.
-        #         I.e. force sentence split when we see an empty line.
+        # Case 1: Two newlines with only whitespace between appear anywhere
+        #         in 'big_text'. I.e. force sentence split when we see an empty line.
         # Case 2: 'big_txt' contains only whitespace.
-        #         This only means "empty line" if each element in text_or_gen is assumed to
-        #         be a line (even if they don't contain any newline characters).
-        #         That does not strictly have to be true and is not a declared assumption,
-        #         except in tests, but the tokenizer has had this behavior for a long time.
+        #         This only means "empty line" if each element in text_or_gen is assumed
+        #         to be a line (even if they don't contain any newline characters).
+        #         That does not strictly have to be true and is not a declared
+        #         assumption, except in tests, but the tokenizer has had this behavior
+        #         for a long time.
 
         if one_sent_per_line:
             # We know there's a single sentence per line
@@ -1506,7 +1508,7 @@ def generate_raw_tokens(
                     if replace_html_escapes:
                         # Replace HTML escapes: '&aacute;' -> 'á'
                         tok = html_replacement(tok)
-                    # The HTML escapes and unicode possibly contain whitespace characters
+                    # HTML escapes and unicode possibly contain whitespace characters
                     # e.g. Em space '&#8195;' and non-breaking space '&nbsp;'
                     # Here we split those tokens into multiple tokens.
                     for small_tok in generate_rough_tokens_from_tok(tok):
@@ -1515,9 +1517,10 @@ def generate_raw_tokens(
                             # We do not want to yield a token with empty text if possible.
                             # We want to attach it in front of the next token, if there is one.
                             # If there is no next token, we attach it in front of the next 'big_text'.
-                            # This will happen when:
+                            # This will happen:
                             # 1. When 'text' has whitespace at the end
-                            # 2. When we have replaced a composite glyph or an HTML escape with whitespace.
+                            # 2. When we have replaced a composite glyph or an HTML
+                            #    escape with whitespace.
                             # See ROUGH_TOKEN_REGEX to convince yourself this is true.
                             saved = small_tok
                         else:
@@ -1831,8 +1834,8 @@ def parse_mixed(
         rtxt = rt.txt
         if rtxt and "@" in rtxt:
             # Check for valid e-mail
-            # Note: we don't allow double quotes (simple or closing ones) in e-mails here
-            # even though they're technically allowed according to the RFCs
+            # Note: we don't allow double quotes (simple or closing ones) in e-mails
+            # here even though they're technically allowed according to the RFCs
             s = re.match(r"[^@\s]+@[^@\s]+(\.[^@\s\.,/:;\"\(\)%#!\?”]+)+", rtxt)
             if s:
                 email, rt = rt.split(s.end())
@@ -2161,8 +2164,8 @@ def parse_particles(token_stream: Iterator[Tok], **options: Any) -> Iterator[Tok
                     if abbrev in Abbreviations.NAME_FINISHERS:
                         # For name finishers (such as 'próf.') we don't consider a
                         # following person name as an indicator of an end-of-sentence
-                        # !!! TODO: This does not work as intended because person names
-                        # !!! have not been recognized at this phase in the token pipeline.
+                        # TODO: This does not work as intended because person names
+                        # have not been recognized at this phase in the token pipeline.
                         test_set = TOK.TEXT_EXCL_PERSON
                     else:
                         test_set = TOK.TEXT
@@ -2179,8 +2182,8 @@ def parse_particles(token_stream: Iterator[Tok], **options: Any) -> Iterator[Tok
                         if abbrev in Abbreviations.FINISHERS:
                             # We see this as an abbreviation even if the next sentence
                             # seems to be starting just after it.
-                            # Yield the abbreviation without a trailing dot,
-                            # and then an 'extra' period token to end the current sentence.
+                            # Yield the abbreviation without a trailing dot, and then
+                            # an 'extra' period token to end the current sentence.
                             token = TOK.Word(token, lookup(abbrev))
                             yield token
                             # Set token to the period
@@ -2306,7 +2309,7 @@ def parse_particles(token_stream: Iterator[Tok], **options: Any) -> Iterator[Tok
 
             # Coalesce ordinals (1. = first, 2. = second...) into a single token
             if next_token.punctuation == ".":
-                if (token.kind == TOK.NUMBER and not "," in token.txt) or (
+                if (token.kind == TOK.NUMBER and "," not in token.txt) or (
                     token.kind == TOK.WORD
                     and RE_ROMAN_NUMERAL.match(token.txt)
                     # Don't interpret a known abbreviation as a Roman numeral,
@@ -2567,14 +2570,14 @@ def parse_sentences(token_stream: Iterator[Tok]) -> Iterator[Tok]:
                         token.punctuation in PUNCT_COMBINATIONS
                         and next_token.punctuation in PUNCT_COMBINATIONS
                     ):
-                        # The normalized form comes from the first token except with "…?"
+                        # Normalized form comes from the first token except with "…?"
                         v = token.punctuation
                         if v == "…" and next_token.punctuation == "?":
                             v = next_token.punctuation
                         token = TOK.Punctuation(token.concatenate(next_token), v)
                         next_token = next(token_stream)
-                    # We may be finishing a sentence with not only a period but also
-                    # right parenthesis and quotation marks
+                    # We may be finishing a sentence with not only a period
+                    # but also right parenthesis and quotation marks
                     while next_token.punctuation in SENTENCE_FINISHERS:
                         yield token
                         token = next_token
@@ -2673,7 +2676,7 @@ def parse_phrases_1(token_stream: Iterator[Tok]) -> Iterator[Tok]:
 
                 month = month_for_token(next_token, True)
                 if month is not None:
-                    if token.kind == TOK.NUMBER and not "." in token.txt:
+                    if token.kind == TOK.NUMBER and "." not in token.txt:
                         # Cases such as "5 mars"
                         token.txt = token.txt + "."
                     token = TOK.Date(
@@ -3053,8 +3056,8 @@ def tokenize(text_or_gen: Union[str, Iterable[str]], **options: Any) -> Iterator
 def tokenize_without_annotation(
     text_or_gen: Union[str, Iterable[str]], **options: Any
 ) -> Iterator[Tok]:
-    """Tokenize without the last pass which can be done more thoroughly if BÍN
-    annotation is available, for instance in GreynirEngine."""
+    """Tokenize without the last pass which can be done more thoroughly
+    if BÍN annotation is available, for instance in GreynirEngine."""
     return tokenize(text_or_gen, with_annotation=False, **options)
 
 
@@ -3304,7 +3307,8 @@ def calculate_indexes(
         else:
             if t.txt:
                 # Origin tracking failed for this token.
-                # TODO: Can we do something better here? Or guarantee that it doesn't happen?
+                # TODO: Can we do something better here?
+                # Or guarantee that it doesn't happen?
                 raise ValueError(
                     f"Origin tracking failed at {t.txt} near index {char_indexes[-1]}"
                 )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,79 @@
+# type: ignore
+
+"""
+    Test the command line interface (CLI) of the tokenizer.
+    Copyright (C) 2025 Miðeind ehf.
+"""
+
+
+from io import StringIO
+import sys
+from unittest.mock import patch
+
+from tokenizer.main import main
+from tokenizer import __version__ as tokenizer_version
+
+
+CLT_NAME = "tokenize"
+
+
+def run_cli(c, m, args: list[str], standard_input: str = "") -> str:
+    """Run the command line interface (CLI) main function with
+    the given arguments and standard input."""
+
+    # Feed the provided string into standard input
+    old_stdin = sys.stdin
+    input = standard_input
+    m.setattr(sys, "stdin", StringIO(input))
+
+    # Run the main function with the provided arguments
+    try:
+        with patch.object(sys, "argv", [CLT_NAME] + args):
+            main()
+    except SystemExit as e:
+        assert e.code == 0, f"Expected exit code 0 from CLT, got {e.code}"
+
+    # Capture the output
+    output = c.readouterr()
+
+    # Restore the original standard input
+    m.setattr(sys, "stdin", old_stdin)
+
+    return output.out.strip()
+
+
+def test_cli(capsys, monkeypatch):
+    """Test the command line interface (CLI) of the tokenizer."""
+    c = capsys
+    m = monkeypatch
+
+    assert run_cli(c, m, ["--version"]).endswith(tokenizer_version)
+    assert "usage:" in run_cli(c, m, ["--help"])
+
+    assert (
+        run_cli(c, m, ["-", "-"], "Hann Jón,sem kom kl.14:00 í dag, fór seinna.")
+        == "Hann Jón , sem kom kl. 14:00 í dag , fór seinna ."
+    )
+
+    def clean_json(s: str) -> str:
+        """Clean the JSON output by removing unnecessary whitespace."""
+        return s.strip()
+
+    expected_json_out = """
+{"k":"BEGIN SENT","t":""}
+{"k":"WORD","t":"Þetta","o":"Þetta","s":[0,1,2,3,4]}
+{"k":"WORD","t":"var","o":" var","s":[1,2,3]}
+{"k":"DATEREL","t":"14. mars","v":[0,3,14],"o":" 14. mars","s":[1,2,3,4,5,6,7,8]}
+{"k":"WORD","t":"og","o":" og","s":[1,2]}
+{"k":"NUMBER","t":"11","v":11,"o":" 11","s":[1,2]}
+{"k":"WORD","t":"manns","o":" manns","s":[1,2,3,4,5]}
+{"k":"WORD","t":"viðstaddir","o":" viðstaddir","s":[1,2,3,4,5,6,7,8,9,10]}
+{"k":"PUNCTUATION","t":".","v":".","o":".","s":[0]}
+{"k":"END SENT","t":""}
+"""
+    r = run_cli(
+        c, m, ["-", "-", "--json"], "Þetta var 14. mars og 11 manns viðstaddir."
+    )
+    assert clean_json(r) == clean_json(expected_json_out)
+
+    # TODO: Add more tests for the CLI to achieve 100% coverage

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -23,8 +23,8 @@ def run_cli(c, m, args: list[str], standard_input: str = "") -> str:
 
     # Feed the provided string into standard input
     old_stdin = sys.stdin
-    input = standard_input
-    m.setattr(sys, "stdin", StringIO(input))
+    input = StringIO(standard_input)
+    m.setattr(sys, "stdin", input)
 
     # Run the main function with the provided arguments
     try:

--- a/test/test_detokenize.py
+++ b/test/test_detokenize.py
@@ -6,7 +6,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2016-2024 by Miðeind ehf.
+    Copyright (C) 2016-2025 by Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:

--- a/test/test_helper_functions.py
+++ b/test/test_helper_functions.py
@@ -1,31 +1,8 @@
 # type: ignore
+
 """
-
-Test helper functions from definitions.py
-
-Copyright (C) 2025 Miðeind ehf.
-
-This software is licensed under the MIT License:
-
-    Permission is hereby granted, free of charge, to any person
-    obtaining a copy of this software and associated documentation
-    files (the "Software"), to deal in the Software without restriction,
-    including without limitation the rights to use, copy, modify, merge,
-    publish, distribute, sublicense, and/or sell copies of the Software,
-    and to permit persons to whom the Software is furnished to do so,
-    subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+    Test helper functions from definitions.py
+    Copyright (C) 2025 Miðeind ehf.
 """
 
 from tokenizer.definitions import valid_ssn, roman_to_int

--- a/test/test_helper_functions.py
+++ b/test/test_helper_functions.py
@@ -1,0 +1,111 @@
+# type: ignore
+"""
+
+Test helper functions from definitions.py
+
+Copyright (C) 2025 Miðeind ehf.
+
+This software is licensed under the MIT License:
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+
+from tokenizer.definitions import valid_ssn, roman_to_int
+
+
+def test_valid_ssn():
+    # Test valid Icelandic SSNs (kennitölur)
+    assert valid_ssn("311281-5189")
+    assert valid_ssn("101275-5239")
+    assert valid_ssn("500101-2880")
+    assert valid_ssn("700269-1169")
+    assert valid_ssn("010130-7789")
+    assert valid_ssn("140543-3229")
+    assert valid_ssn("120375-3509")
+    assert valid_ssn("650376-0649")
+
+    # Test invalid formats - wrong length
+    assert not valid_ssn("01010-1019")
+    assert not valid_ssn("0101011019")
+    assert not valid_ssn("010101-10199")
+    assert not valid_ssn("")
+    assert not valid_ssn(None)
+
+    # Test invalid formats - no hyphen
+    assert not valid_ssn("0101011019")
+    assert not valid_ssn("010101+1019")
+    assert not valid_ssn("010101 1019")
+
+    # Test invalid formats - hyphen in wrong position
+    assert not valid_ssn("01010-11019")
+    assert not valid_ssn("0101011-019")
+
+    # Test checksum failures
+    assert not valid_ssn("010101-0000")
+    assert not valid_ssn("010101-1018")
+    assert not valid_ssn("310354-2268")
+
+    # Test invalid format - non-digit characters
+    assert not valid_ssn("01010A-1019")
+    assert not valid_ssn("010101-10B9")
+
+    # Test completely malformed inputs
+    assert not valid_ssn("abcde-fghi")
+    assert not valid_ssn("12345")
+    assert not valid_ssn("not-a-ssn")
+
+
+def test_roman_to_int():
+    # Test basic single numerals
+    assert roman_to_int("I") == 1
+    assert roman_to_int("V") == 5
+    assert roman_to_int("X") == 10
+    assert roman_to_int("L") == 50
+    assert roman_to_int("C") == 100
+    assert roman_to_int("D") == 500
+    assert roman_to_int("M") == 1000
+
+    # Test subtractive notation
+    assert roman_to_int("IV") == 4
+    assert roman_to_int("IX") == 9
+    assert roman_to_int("XL") == 40
+    assert roman_to_int("XC") == 90
+    assert roman_to_int("CD") == 400
+    assert roman_to_int("CM") == 900
+
+    # Test additive notation and combinations
+    assert roman_to_int("II") == 2
+    assert roman_to_int("III") == 3
+    assert roman_to_int("VI") == 6
+    assert roman_to_int("VII") == 7
+    assert roman_to_int("VIII") == 8
+    assert roman_to_int("XI") == 11
+    assert roman_to_int("XV") == 15
+    assert roman_to_int("XVI") == 16
+
+    # Test various complex numbers
+    assert roman_to_int("XXIV") == 24
+    assert roman_to_int("XLII") == 42
+    assert roman_to_int("XCIX") == 99
+    assert roman_to_int("CDXLIV") == 444
+    assert roman_to_int("MCMXCIX") == 1999
+    assert roman_to_int("MMXXIII") == 2023
+    assert roman_to_int("MMMCMXCIX") == 3999

--- a/test/test_index_calculation.py
+++ b/test/test_index_calculation.py
@@ -6,7 +6,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2016-2024 by Miðeind ehf.
+    Copyright (C) 2016-2025 by Miðeind ehf.
 
     This software is licensed under the MIT License:
 

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -5,7 +5,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2016-2024 by Miðeind ehf.
+    Copyright (C) 2016-2025 by Miðeind ehf.
     Original author: Vilhjálmur Þorsteinsson
 
     This software is licensed under the MIT License:
@@ -50,9 +50,9 @@ def strip_originals(tokens: list[Tok]) -> list[Tok]:
     tracking during tokenization.
     """
 
-    for t in tokens:
-        t.original = None
-        t.origin_spans = None
+    for tk in tokens:
+        tk.original = None
+        tk.origin_spans = None
 
     return tokens
 
@@ -570,11 +570,11 @@ def test_single_tokens() -> None:
             else:
                 txt, kind = cast(tuple[str, int], test_case)
                 c = [Tok(kind, txt, None)]
-            l = list(t.tokenize(txt, **options))
-            assert len(l) == len(c) + 2, repr(l)
-            assert l[0].kind == TOK.S_BEGIN, repr(l[0])
-            assert l[-1].kind == TOK.S_END, repr(l[-1])
-            for tok, check in zip(l[1:-1], c):
+            lt = list(t.tokenize(txt, **options))
+            assert len(lt) == len(c) + 2, repr(lt)
+            assert lt[0].kind == TOK.S_BEGIN, repr(lt[0])
+            assert lt[-1].kind == TOK.S_END, repr(lt[-1])
+            for tok, check in zip(lt[1:-1], c):
                 assert tok.kind == check.kind, (
                     tok.txt
                     + ": "

--- a/test/test_tokenizer_tok.py
+++ b/test/test_tokenizer_tok.py
@@ -3,7 +3,7 @@
 
     Tests for Tokenizer module
 
-    Copyright (C) 2016-2024 by Miðeind ehf.
+    Copyright (C) 2016-2025 by Miðeind ehf.
 
     This software is licensed under the MIT License:
 


### PR DESCRIPTION
* CI uses `uv` for faster dep. installation, and now tests on CPython 3.13 release
* Rm unused __future__ and typing_extensions
* Added --version CLI flag
* Various typing and linter fixes
* Bumped copyright header year
* Added tests for helper functions and CLI to increase test coverage (#23)

```
pytest --cov=src/tokenizer
```

For HTML report to view uncovered lines:

```
pytest --cov=src/tokenizer --cov-report=html
```

# Before

```
Name                           Stmts   Miss  Cover
--------------------------------------------------
src/tokenizer/__init__.py          8      0   100%
src/tokenizer/abbrev.py          156     11    93%
src/tokenizer/definitions.py     129      1    99%
src/tokenizer/main.py            113    113     0%
src/tokenizer/tokenizer.py      1670    296    82%
--------------------------------------------------
TOTAL                           2076    421    80%
```

# After

```
Name                           Stmts   Miss  Cover
--------------------------------------------------
src/tokenizer/__init__.py          8      0   100%
src/tokenizer/abbrev.py          156     11    93%
src/tokenizer/definitions.py     129      0   100%
src/tokenizer/main.py            115     29    75%
src/tokenizer/tokenizer.py      1670    296    82%
--------------------------------------------------
TOTAL                           2078    336    84%
```