### PR TITLE
OrderedSet can use plain ol' dict instead of OrderedDict in Python 3.7+

### DIFF
--- a/src/tokenizer/abbrev.py
+++ b/src/tokenizer/abbrev.py
@@ -36,7 +36,7 @@
 from typing import Generic, Iterator, Optional, TypeVar
 
 from threading import Lock
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 import importlib.resources as importlib_resources
 
 from .definitions import BIN_Tuple
@@ -51,23 +51,30 @@ _T = TypeVar("_T")
 
 class OrderedSet(Generic[_T]):
     """Shim class to provide an ordered set API on top
-    of an OrderedDict. This is necessary to make abbreviation
+    of a dictionary. This is necessary to make abbreviation
     lookups predictable and repeatable, which they would not be
     if a standard Python set() was used."""
 
     def __init__(self) -> None:
-        self._dict: dict[_T, None] = OrderedDict()
+        # Insertions are ordered in Python 3.7+ dicts
+        self._dict: dict[_T, None] = {}
 
     def add(self, item: _T) -> None:
         """Add an item at the end of the ordered set"""
-        if item not in self._dict:
-            self._dict[item] = None
+        # For plain dicts in Python 3.7+, direct assignment works:
+        # * If item is new, it is added at the end.
+        # * If item already exists, its value is updated (to None again),
+        #   and the order remains unchanged.
+        self._dict[item] = None
 
     def __contains__(self, item: _T) -> bool:
         return item in self._dict
 
     def __iter__(self) -> Iterator[_T]:
         return self._dict.__iter__()
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({list(self._dict.keys())})"
 
 
 class Abbreviations:

--- a/src/tokenizer/abbrev.py
+++ b/src/tokenizer/abbrev.py
@@ -332,7 +332,7 @@ class Abbreviations:
                     # Blank line: ignore
                     continue
                 if s[0] == "[":
-                    # Section header (we are expecting [abbreviations]/[not_abbreviations])
+                    # Section header (we expect [abbreviations]/[not_abbreviations])
                     if s not in {"[abbreviations]", "[not_abbreviations]"}:
                         raise ConfigError("Wrong section header")
                     section = s

--- a/test/test_abbrev.py
+++ b/test/test_abbrev.py
@@ -1,0 +1,39 @@
+# type: ignore
+
+from tokenizer.abbrev import OrderedSet
+
+def test_ordered_set():
+    # Test empty set
+    s_empty = OrderedSet()
+    assert list(s_empty) == []
+    assert 1 not in s_empty
+    assert repr(s_empty) == "OrderedSet([])"
+
+    # Test add and iteration order
+    s_order = OrderedSet()
+    s_order.add(1)
+    s_order.add('a')
+    s_order.add(3.0)
+    assert list(s_order) == [1, 'a', 3.0]
+
+    # Test add existing item preserves order and uniqueness
+    s_existing = OrderedSet()
+    s_existing.add(10)
+    s_existing.add(20)
+    s_existing.add(10) # Add existing
+    assert list(s_existing) == [10, 20]
+
+    # Test contains
+    s_contains = OrderedSet()
+    s_contains.add('x')
+    s_contains.add('y')
+    assert 'x' in s_contains
+    assert 'y' in s_contains
+    assert 'z' not in s_contains
+    assert 'a' not in s_contains
+
+    # Test repr non-empty
+    s_repr = OrderedSet()
+    s_repr.add(1)
+    s_repr.add('foo')
+    assert repr(s_repr) == "OrderedSet([1, 'foo'])"

--- a/test/test_tokenizer.py
+++ b/test/test_tokenizer.py
@@ -2575,15 +2575,3 @@ def test_one_sent_per_line() -> None:
         Tok(kind=11002, txt=None, val=None),
     ]
     assert toklist == correct
-
-
-if __name__ == "__main__":
-    test_single_tokens()
-    test_sentences()
-    test_correct_spaces()
-    test_correction()
-    test_abbrev()
-    test_overlap()
-    test_split_sentences()
-    test_normalization()
-    test_html_escapes()


### PR DESCRIPTION
* OrderedSet can use plain ol' dict instead of OrderedDict in Python 3.7+

#53
