### PR TITLE
Release Tokenizer 3.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ using a 64-bit 2.6 GHz Intel Core i9:
 
 Running tokenization with PyPy is about 3x faster than with CPython.
 
-Version 3.6.3 reduces the cost of origin tracking by materializing
-`origin_spans` lazily. On `test/toktest_large.txt` (573 KB, about 149k tokens),
-this improved CPython tokenization throughput by roughly 8-12% and reduced
-peak memory by about 9 MB when retaining the token list.
+Version 3.6.4 avoids a redundant whitespace-tokenization pass for normal input,
+while retaining the additional pass when HTML escape replacement can introduce
+whitespace. On `test/toktest_large.txt` (573 KB, about 149k tokens), this reduces
+CPython tokenization time by roughly 20% compared with version 3.6.3, with
+identical token text, values, original text and origin spans.
 
 ## Deep vs. shallow tokenization
 
@@ -716,6 +717,11 @@ can be found in the file `test/toktest_normal_gold_expected.txt`.
 
 ## Changelog
 
+* Version 3.6.4: Improved tokenization performance by constructing rough tokens
+  directly with their lazy origin offsets and skipping a redundant second
+  whitespace-tokenization pass unless HTML escape replacement is enabled. This
+  reduces CPython tokenization time by roughly 20% on the large test corpus while
+  preserving token output and origin tracking.
 * Version 3.6.3: Improved origin tracking performance by materializing
   `origin_spans` lazily, while preserving the public token API and index
   behavior. Fixed validation edge cases in `valid_ssn()`, Roman numeral

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokenizer"
-version = "3.6.3"
+version = "3.6.4"
 description = "A fast, compact pure-Python tokenizer for Icelandic text with sentence segmentation"
 authors = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]
 maintainers = [{ name = "Vilhjálmur Þorsteinsson", email = "vt@mideind.is" }]

--- a/src/tokenizer/tokenizer.py
+++ b/src/tokenizer/tokenizer.py
@@ -1518,7 +1518,16 @@ def generate_rough_tokens_from_txt(text: str) -> Iterator[Tok]:
         match = ROUGH_TOKEN_REGEX.match(text, pos)
         assert match is not None
         match_span = match.span(ROUGH_TOKEN_REGEX_ENTIRE_MATCH)
-        tok = Tok.from_txt(text[match_span[SPAN_START] : match_span[SPAN_END]])
+        whitespace_span = match.span(ROUGH_TOKEN_REGEX_WHITE_SPACE_GROUP)
+        token_span = match.span(ROUGH_TOKEN_REGEX_TOKEN_GROUP)
+        tok = Tok(
+            TOK.RAW,
+            text[token_span[SPAN_START] : token_span[SPAN_END]],
+            None,
+            text[match_span[SPAN_START] : match_span[SPAN_END]],
+            lazy_origin_spans=True,
+            lazy_origin_offset=whitespace_span[SPAN_END] - match_span[SPAN_START],
+        )
         pos = match_span[SPAN_END]
         yield tok
 
@@ -1643,10 +1652,15 @@ def generate_raw_tokens(
                     if replace_html_escapes:
                         # Replace HTML escapes: '&aacute;' -> 'á'
                         tok = html_replacement(tok)
-                    # HTML escapes and unicode may contain whitespace characters
-                    # e.g. Em space '&#8195;' and non-breaking space '&nbsp;'
-                    # Here we split those tokens into multiple tokens.
-                    for small_tok in generate_rough_tokens_from_tok(tok):
+                    # HTML escapes may introduce whitespace characters, e.g. Em
+                    # space '&#8195;' and non-breaking space '&nbsp;'. Only that
+                    # optional replacement requires another rough-token pass.
+                    small_tokens: Iterable[Tok] = (
+                        generate_rough_tokens_from_tok(tok)
+                        if replace_html_escapes
+                        else (tok,)
+                    )
+                    for small_tok in small_tokens:
                         if small_tok.txt == "":
                             # There was whitespace at the end of the last token.
                             # We do not want to yield a token with empty text


### PR DESCRIPTION
## Summary
- avoid the redundant second rough-token whitespace pass during normal tokenization
- retain the pass when HTML escape replacement can introduce whitespace
- bump the package version to 3.6.4 and document the performance improvement

## Performance
On `test/toktest_large.txt` (149,040 tokens), median CPython tokenization time decreased from 1.905 s to 1.514 s (20.5%). Profiled calls decreased from 9.32M to 7.77M.

## Verification
- `pytest`: 151 passed
- `ruff check .`: passed
- `mypy src/tokenizer`: passed
- source distribution and wheel built successfully
- `twine check`: passed
- local clean-venv wheel smoke test: passed
- all deep-token fields, including origin spans, matched master on the large corpus